### PR TITLE
fix: install Font Awesome locally 

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,9 +27,15 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "**/*",
+                "input": "node_modules/@fortawesome/fontawesome-free/webfonts",
+                "output": "assets/webfonts"
               }
             ],
             "styles": [
+              "node_modules/@fortawesome/fontawesome-free/css/all.min.css",
               "src/styles.scss"
             ]
           },

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,6 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
This pull request updates how Font Awesome is included in the project, switching from a CDN-based approach to bundling the assets locally. This improves reliability and performance by ensuring all required font files and styles are packaged with the application.

**Font Awesome asset management:**

* Added Font Awesome webfonts to the build by copying them from `node_modules/@fortawesome/fontawesome-free/webfonts` to `assets/webfonts` in `angular.json`.
* Included the local Font Awesome CSS file (`all.min.css`) in the build styles in `angular.json` and removed the external CDN link from `src/index.html`. [[1]](diffhunk://#diff-2d2675bb4687601a5c7ccf707455132f90f3516a33716185687e5c41df59ac7dR30-R38) [[2]](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL9)